### PR TITLE
fix: crash in write_nfo_movies when settings does not have 'set'

### DIFF
--- a/plugin.video.youtubelibrary/resources/lib/generators.py
+++ b/plugin.video.youtubelibrary/resources/lib/generators.py
@@ -994,7 +994,7 @@ def write_nfo_movies(info, settings):
     #Prepare optional xml tags if they are set
     info['director'] = settings.find('channel').text
     set = ''
-    if len(settings.find('set').text) > 0:
+    if settings.find('set') and len(settings.find('set').text) > 0:
         set = '<set>'+settings.find('set').text+'</set>'
                 
     #If smart_search is enabled, try to grab info like, year, director and actors from the title & description on youtube, and clean up the title and description in the process


### PR DESCRIPTION
Don't know much about the context, but in the kodi.log there was a stacktrace,
and after the fix it seems to work properly.

The stacktrace:

```
15:09:34 69116.218750 T:1540502432   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.TypeError'>
                                            Error Contents: object of type 'NoneType' has no len()
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/plugin.video.youtubelibrary/addon.py", line 147, in <module>
                                                routes.update_playlist(type=type)
                                              File "/storage/.kodi/addons/plugin.video.youtubelibrary/resources/lib/routes.py", line 62, in update_playlist
                                                service.update_playlist(id, type=type)
                                              File "/storage/.kodi/addons/plugin.video.youtubelibrary/resources/lib/service.py", line 221, in update_playlist
                                                if update_playlist_vids(id, folder, settings, type=type) == False:
                                              File "/storage/.kodi/addons/plugin.video.youtubelibrary/resources/lib/service.py", line 402, in update_playlist_vids
                                                create_strm = generators.write_nfo(filename, folder, vid, settings, duration = duration[vid['contentDetails']['videoId']], type=type) #Write the n
fo file for this episode
                                              File "/storage/.kodi/addons/plugin.video.youtubelibrary/resources/lib/generators.py", line 967, in write_nfo
                                                content = write_nfo_movies(info, settings)
                                              File "/storage/.kodi/addons/plugin.video.youtubelibrary/resources/lib/generators.py", line 997, in write_nfo_movies
                                                if len(settings.find('set').text) > 0:
                                            TypeError: object of type 'NoneType' has no len()
                                            -->End of Python script error report<--
15:09:34 69116.812500 T:1540502432    INFO: Python script stopped
```